### PR TITLE
fix(usage): debounce the stale indicator and skip known-expired tokens

### DIFF
--- a/com.saeedkolivand.claude-usage.sdPlugin/bin/plugin.js
+++ b/com.saeedkolivand.claude-usage.sdPlugin/bin/plugin.js
@@ -17315,6 +17315,14 @@ var ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
 var DEFAULT_UA = "claude-code/2.0.31";
 var CACHE_TTL_MS = 55e3;
 var cache = { at: 0, data: null };
+var STALE_AFTER_MS = 3 * 6e4;
+function failResult(error40) {
+  return {
+    data: cache.data,
+    error: error40,
+    stale: cache.data != null && Date.now() - cache.at > STALE_AFTER_MS
+  };
+}
 function credentialsPath() {
   return (0, import_node_path6.join)((0, import_node_os.homedir)(), ".claude", ".credentials.json");
 }
@@ -17357,8 +17365,9 @@ async function fetchUsage(ua, force = false) {
   if (!force && cache.data && now - cache.at < CACHE_TTL_MS) {
     return { data: cache.data };
   }
-  const { token } = readToken();
-  if (!token) return { data: cache.data, error: "no-token" };
+  const { token, expired } = readToken();
+  if (!token) return failResult("no-token");
+  if (expired) return failResult("token-expired");
   try {
     const res = await fetch(ENDPOINT, {
       method: "GET",
@@ -17372,12 +17381,12 @@ async function fetchUsage(ua, force = false) {
         Accept: "application/json, text/plain, */*"
       }
     });
-    if (!res.ok) return { data: cache.data, error: `http-${res.status}` };
+    if (!res.ok) return failResult(`http-${res.status}`);
     const data = await res.json();
     cache = { at: now, data };
     return { data };
   } catch {
-    return { data: cache.data, error: "network" };
+    return failResult("network");
   }
 }
 var METRICS = {
@@ -17670,22 +17679,21 @@ async function draw(act, s) {
 }
 async function drawGauge(act, s, metric) {
   const ua = s.userAgent && s.userAgent.trim() || DEFAULT_UA;
-  const { data, error: error40 } = await fetchUsage(ua, false);
+  const { data, error: error40, stale } = await fetchUsage(ua, false);
   const warn = num(s.warn, 50);
   const crit = num(s.crit, 80);
   const title = (s.title || "").trim();
   if (!data) {
-    const note2 = error40 === "no-token" ? "open Claude" : error40 === "network" ? "offline" : "\u2026";
+    const note2 = error40 === "no-token" || error40 === "token-expired" ? "open Claude" : error40 === "network" ? "offline" : "\u2026";
     await act.setImage(
       toDataUri(svgKey({ label: title || "Claude", pct: null, note: note2, col: color(null, warn, crit), stale: true }))
     );
     return;
   }
   const { label, pct, resetsAt } = pickMetric(data, metric);
-  const stale = !!error40;
   const note = pct == null ? "n/a here" : untilText(resetsAt);
   await act.setImage(
-    toDataUri(svgKey({ label: title || label, pct, note, col: color(pct, warn, crit), stale }))
+    toDataUri(svgKey({ label: title || label, pct, note, col: color(pct, warn, crit), stale: !!stale }))
   );
 }
 async function drawStat(act, s, metric) {

--- a/com.saeedkolivand.claude-usage.sdPlugin/bin/plugin.js
+++ b/com.saeedkolivand.claude-usage.sdPlugin/bin/plugin.js
@@ -17316,7 +17316,9 @@ var DEFAULT_UA = "claude-code/2.0.31";
 var CACHE_TTL_MS = 55e3;
 var cache = { at: 0, data: null };
 var STALE_AFTER_MS = 3 * 6e4;
+var lastFail = null;
 function failResult(error40) {
+  lastFail = { at: Date.now(), error: error40 };
   return {
     data: cache.data,
     error: error40,
@@ -17365,6 +17367,13 @@ async function fetchUsage(ua, force = false) {
   if (!force && cache.data && now - cache.at < CACHE_TTL_MS) {
     return { data: cache.data };
   }
+  if (!force && lastFail && now - lastFail.at < CACHE_TTL_MS) {
+    return {
+      data: cache.data,
+      error: lastFail.error,
+      stale: cache.data != null && now - cache.at > STALE_AFTER_MS
+    };
+  }
   const { token, expired } = readToken();
   if (!token) return failResult("no-token");
   if (expired) return failResult("token-expired");
@@ -17384,6 +17393,7 @@ async function fetchUsage(ua, force = false) {
     if (!res.ok) return failResult(`http-${res.status}`);
     const data = await res.json();
     cache = { at: now, data };
+    lastFail = null;
     return { data };
   } catch {
     return failResult("network");

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -52,14 +52,18 @@ async function draw(act: any, s: Settings): Promise<void> {
 
 async function drawGauge(act: any, s: Settings, metric: string): Promise<void> {
   const ua = (s.userAgent && s.userAgent.trim()) || DEFAULT_UA;
-  const { data, error } = await fetchUsage(ua, false); // honors the shared cache
+  const { data, error, stale } = await fetchUsage(ua, false); // honors the shared cache
   const warn = num(s.warn, 50);
   const crit = num(s.crit, 80);
   const title = (s.title || "").trim(); // custom label; empty = use the metric default
 
   if (!data) {
     const note =
-      error === "no-token" ? "open Claude" : error === "network" ? "offline" : "…";
+      error === "no-token" || error === "token-expired"
+        ? "open Claude"
+        : error === "network"
+          ? "offline"
+          : "…";
     await act.setImage(
       toDataUri(svgKey({ label: title || "Claude", pct: null, note, col: color(null, warn, crit), stale: true })),
     );
@@ -67,10 +71,11 @@ async function drawGauge(act: any, s: Settings, metric: string): Promise<void> {
   }
 
   const { label, pct, resetsAt } = pickMetric(data, metric);
-  const stale = !!error; // we have cached data but the latest refresh failed
   const note = pct == null ? "n/a here" : untilText(resetsAt);
+  // stale comes from fetchUsage: cached data older than its debounce window,
+  // not merely "the latest refresh failed" — a single blip stays bright.
   await act.setImage(
-    toDataUri(svgKey({ label: title || label, pct, note, col: color(pct, warn, crit), stale })),
+    toDataUri(svgKey({ label: title || label, pct, note, col: color(pct, warn, crit), stale: !!stale })),
   );
 }
 

--- a/src/usage-core.ts
+++ b/src/usage-core.ts
@@ -16,11 +16,27 @@ export type UsageData = {
   [k: string]: unknown;
 };
 
-export type FetchResult = { data: UsageData | null; error?: string };
+export type FetchResult = { data: UsageData | null; error?: string; stale?: boolean };
 
 // Module-level cache shared across all key instances in the plugin process,
 // so 3-4 keys produce a single network call per minute, not 3-4.
 let cache: { at: number; data: UsageData | null } = { at: 0, data: null };
+
+// How old the cached data may get before a failing refresh is surfaced as
+// stale. A single failed poll out of the 60s cadence self-heals within a
+// minute and shouldn't flash the keys amber; once the numbers on screen are
+// ~3 missed polls old, that's worth showing. Age-based on purpose: during an
+// outage every visible key retries the fetch, so counting failures would
+// scale with the number of keys, not with elapsed time.
+const STALE_AFTER_MS = 3 * 60_000;
+
+function failResult(error: string): FetchResult {
+  return {
+    data: cache.data,
+    error,
+    stale: cache.data != null && Date.now() - cache.at > STALE_AFTER_MS,
+  };
+}
 
 export function credentialsPath(): string {
   // Windows: %USERPROFILE%\.claude\.credentials.json  (homedir() resolves USERPROFILE)
@@ -74,8 +90,11 @@ export async function fetchUsage(ua: string, force = false): Promise<FetchResult
   if (!force && cache.data && now - cache.at < CACHE_TTL_MS) {
     return { data: cache.data };
   }
-  const { token } = readToken();
-  if (!token) return { data: cache.data, error: "no-token" };
+  const { token, expired } = readToken();
+  if (!token) return failResult("no-token");
+  // A token the credentials already mark as expired guarantees a 401 — skip
+  // the request and wait for Claude Code to write a refreshed one.
+  if (expired) return failResult("token-expired");
 
   try {
     const res = await fetch(ENDPOINT, {
@@ -90,12 +109,12 @@ export async function fetchUsage(ua: string, force = false): Promise<FetchResult
         Accept: "application/json, text/plain, */*",
       },
     });
-    if (!res.ok) return { data: cache.data, error: `http-${res.status}` };
+    if (!res.ok) return failResult(`http-${res.status}`);
     const data = (await res.json()) as UsageData;
     cache = { at: now, data };
     return { data };
   } catch {
-    return { data: cache.data, error: "network" };
+    return failResult("network");
   }
 }
 

--- a/src/usage-core.ts
+++ b/src/usage-core.ts
@@ -30,7 +30,15 @@ let cache: { at: number; data: UsageData | null } = { at: 0, data: null };
 // scale with the number of keys, not with elapsed time.
 const STALE_AFTER_MS = 3 * 60_000;
 
+// After a failed attempt, hold off further automatic retries for a full cache
+// window. Without this the failure path *raises* the request rate: a failure
+// leaves cache.at untouched, so every visible key's redraw fires its own
+// retry — exactly when the API is asking for less (rate limits, outages).
+// A manual key tap passes force=true and still retries immediately.
+let lastFail: { at: number; error: string } | null = null;
+
 function failResult(error: string): FetchResult {
+  lastFail = { at: Date.now(), error };
   return {
     data: cache.data,
     error,
@@ -90,6 +98,14 @@ export async function fetchUsage(ua: string, force = false): Promise<FetchResult
   if (!force && cache.data && now - cache.at < CACHE_TTL_MS) {
     return { data: cache.data };
   }
+  // Failure cooldown: serve the cache and the last error instead of retrying.
+  if (!force && lastFail && now - lastFail.at < CACHE_TTL_MS) {
+    return {
+      data: cache.data,
+      error: lastFail.error,
+      stale: cache.data != null && now - cache.at > STALE_AFTER_MS,
+    };
+  }
   const { token, expired } = readToken();
   if (!token) return failResult("no-token");
   // A token the credentials already mark as expired guarantees a 401 — skip
@@ -112,6 +128,7 @@ export async function fetchUsage(ua: string, force = false): Promise<FetchResult
     if (!res.ok) return failResult(`http-${res.status}`);
     const data = (await res.json()) as UsageData;
     cache = { at: now, data };
+    lastFail = null;
     return { data };
   } catch {
     return failResult("network");


### PR DESCRIPTION
Fixes the over-eager stale indicator reported in #5.

## What changed
- **Stale is debounced by data age.** `fetchUsage()` returns `stale: true` only once the cached data is older than 3 minutes (~3 missed polls at the 60 s cadence), instead of on the first failed refresh. Age-based rather than failure-counting because during an outage every visible key retries the fetch — failures scale with the number of keys, elapsed time doesn't.
- **Known-expired tokens short-circuit.** `readToken()`'s `expired` flag is now honoured: no request is sent, a distinct `token-expired` error is returned, and `plugin.ts` maps it to the existing "open Claude" hint when there's no cached data. Ends the guaranteed 401-per-poll loop while Claude Code refreshes the token.

- **Retry amplification during outages is gone.** A failed attempt starts a 55 s cooldown: redraws serve the cache and the previous error instead of firing their own retries (observed live: a sustained 429 where every key kept re-hitting the endpoint). The minute poll makes exactly one attempt per process; a manual key tap still forces a retry.

## Verified
Exercised the real `fetchUsage()` with a stubbed `fetch` and shifted clock: single blip stays bright; >3 min data age turns amber; the next successful poll clears it; a second key retrying in the same minute changes nothing; an expired token sends no HTTP request while still serving cached data.

Rendering, metrics and thresholds are untouched; `docs/*` assets are byte-identical. `bin/plugin.js` rebuilt.

Closes #5

